### PR TITLE
[MKTKERNEL-836] Update gooddata.gemspec

### DIFF
--- a/gooddata.gemspec
+++ b/gooddata.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3' if RUBY_PLATFORM != 'java'
 
   if RUBY_VERSION >= '2.5'
-    s.add_dependency 'activesupport', '>= 6.0.3.1', '< 7.1'
+    s.add_dependency 'activesupport', '>= 6.0.3.1', '< 7.2'
   else
     s.add_dependency 'activesupport', '>= 5.2.4.3', '< 6.0'
   end


### PR DESCRIPTION
## Descrição :memo: 

Estamos atualizando o gemspec desse fork para possibilitar o uso da gem **activesupport** em versão superior a 7.1. Este é um requisito para o bump da versão do **Rails** do projeto RD Station Marketing para a versão 7.1

![image](https://github.com/ResultadosDigitais/gooddata-ruby/assets/85767928/09ca9d88-2d9e-4360-bb3b-267406678c7b)
 